### PR TITLE
Updated z-schema to version 3.15.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "debug": false
   },
   "dependencies": {
-    "z-schema": "3.15.2"
+    "z-schema": "3.15.3"
   },
   "devDependencies": {
     "chai": "3.2.0",


### PR DESCRIPTION
:rocket:

z-schema just published version 3.15.3, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---
The new version differs by 3 commits (ahead by 3, behind by 0).

- [595e827](https://github.com/zaggino/z-schema/commit/595e827570c25cb69ec172caa897323218ed01b0): Version 3.15.3
- [8d912bb](https://github.com/zaggino/z-schema/commit/8d912bb58a7e645725d3407b2f281d148a5fa5f0): Merge pull request #141 from APIs-guru/master
- [be5bf69](https://github.com/zaggino/z-schema/commit/be5bf6968b9e45abb4d205c9e8f5f7a7b219c4ef): Handle incorrect id keyword

See the [full diff](https://github.com/zaggino/z-schema/compare/a13ec1b33cf46c8ddf9009c3edfb399ee0480d82...595e827570c25cb69ec172caa897323218ed01b0).

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>